### PR TITLE
Allow group users write to the controlling UNIX-socket.

### DIFF
--- a/main.c
+++ b/main.c
@@ -421,6 +421,8 @@ init_controlfd(struct cfg *cf)
 	if ((cf->run_uname != NULL || cf->run_gname != NULL) &&
 	  chown(cmd_sock, cf->run_uid, cf->run_gid) == -1)
 	    err(1, "can't set owner of the socket");
+	if (chmod(cmd_sock, 0775) == -1)
+	    err(1, "can't allow rw acces to group");
 	if (listen(controlfd, 32) != 0)
 	    err(1, "can't listen on a socket");
     } else {


### PR DESCRIPTION
No visible changes for BSD users, so this is Linux-only
related issue. See this RHBZ for rationale:

https://bugzilla.redhat.com/626863

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>rtpproxy-1